### PR TITLE
New mods to copy item's MD link

### DIFF
--- a/getRecordListByTags.py
+++ b/getRecordListByTags.py
@@ -108,7 +108,8 @@ for itemInfoStr in infoList:
         "icon": {"type": "fileicon", "path": itemPath},
         "mods": {
             "cmd": {"valid": True, "arg": itemUUID, "subtitle": "🏷 " + ", ".join(itemTagList)},
-            "alt": {"valid": True, "arg": itemUUID, "subtitle": "Reveal in DEVONthink"}
+            "alt": {"valid": True, "arg": itemUUID, "subtitle": "Reveal in DEVONthink"},
+            "shift": {"valid": True, "arg": "[" + itemName + "]" + "(x-devonthink-item://" + itemUUID + ")", "subtitle": "Set \"" + "[" + itemName + "]" + "(x-devonthink-item://" + itemUUID + ")" + "\" to the clipboard"}
         },
         "text": {
             "copy": "x-devonthink-item://" + itemUUID,

--- a/info.plist
+++ b/info.plist
@@ -38,6 +38,16 @@
 				<key>vitoclose</key>
 				<false/>
 			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>2F0D7AF6-77D1-45C2-AB02-776F4BA590A1</string>
+				<key>modifiers</key>
+				<integer>131072</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
 		</array>
 		<key>2D684BD7-1242-42F0-8AA4-C968A5285FD5</key>
 		<array>
@@ -219,6 +229,16 @@
 				<key>vitoclose</key>
 				<false/>
 			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>2F0D7AF6-77D1-45C2-AB02-776F4BA590A1</string>
+				<key>modifiers</key>
+				<integer>131072</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
 		</array>
 		<key>FD00A4FC-B807-4081-8AB4-9AEAC5EC2525</key>
 		<array>
@@ -247,6 +267,16 @@
 				<string>72C81C8A-AD3A-4675-A407-B01AD86F0592</string>
 				<key>modifiers</key>
 				<integer>524288</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>2F0D7AF6-77D1-45C2-AB02-776F4BA590A1</string>
+				<key>modifiers</key>
+				<integer>131072</integer>
 				<key>modifiersubtext</key>
 				<string></string>
 				<key>vitoclose</key>
@@ -723,6 +753,30 @@ open "x-devonthink-item://${1}?reveal=1"</string>
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string># $1: uuid
+echo "${1}" | pbcopy</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>2F0D7AF6-77D1-45C2-AB02-776F4BA590A1</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
 				<key>alfredfiltersresults</key>
 				<true/>
 				<key>alfredfiltersresultsmatchmode</key>
@@ -910,6 +964,15 @@ open "x-devonthink-item://${1}?reveal=1"</string>
 			<integer>270</integer>
 			<key>ypos</key>
 			<integer>1105</integer>
+		</dict>
+		<key>2F0D7AF6-77D1-45C2-AB02-776F4BA590A1</key>
+		<dict>
+			<key>note</key>
+			<string>Copy item's MD-link</string>
+			<key>xpos</key>
+			<integer>815</integer>
+			<key>ypos</key>
+			<integer>755</integer>
 		</dict>
 		<key>463F4584-47AD-4B3E-B822-3D194043A268</key>
 		<dict>

--- a/search.js
+++ b/search.js
@@ -91,7 +91,8 @@ function run(argv) {
             item["mods"] = {
                 "cmd": { "valid": true, "arg": itemUUID, "subtitle": "🏷 " + itemTagStr },
                 "alt": { "valid": true, "arg": itemUUID, "subtitle": "Reveal in DEVONthink" },
-                "cmd+alt": { "valid": true, "arg": argv[0], "subtitle": "Search in DEVONthink App" }
+                "cmd+alt": { "valid": true, "arg": argv[0], "subtitle": "Search in DEVONthink App" },
+                "shift": {"valid": True, "arg": "[" + itemName + "]" + "(x-devonthink-item://" + itemUUID + ")", "subtitle": "Set \"" + "[" + itemName + "]" + "(x-devonthink-item://" + itemUUID + ")" + "\" to the clipboard"}
             }
             item["text"] = {
                 "copy": "x-devonthink-item://" + itemUUID,


### PR DESCRIPTION
Added mods to copy an item's link in MD format, that is, [itemName](x-devonthink-item://...).

"shift": {"valid": True, "arg": "[" + itemName + "]" + "(x-devonthink-item://" + itemUUID + ")", "subtitle": "Set \"" + "[" + itemName + "]" + "(x-devonthink-item://" + itemUUID + ")" + "\" to the clipboard"}